### PR TITLE
Add training and prediction scripts with model utilities

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+__pycache__/
+models/
+*.joblib

--- a/README.md
+++ b/README.md
@@ -1,2 +1,25 @@
 # MMA-Random-Forest-Tabular-Predictor
-Using Tabular UFC fight data to predict winners from a given matchup 
+Using Tabular UFC fight data to predict winners from a given matchup
+
+## Setup
+Install dependencies:
+
+```
+pip install -r requirements.txt
+```
+
+## Training
+Train models and save them to the `models/` directory:
+
+```
+python train.py
+```
+
+## Prediction
+Load the saved models and generate predictions for a matchup:
+
+```
+python predict.py --fighter1 "Alexa Grasso" --fighter2 "Valentina Shevchenko" --referee "Herb Dean"
+```
+
+The script prints predicted fight statistics along with the result, method and round.

--- a/predict.py
+++ b/predict.py
@@ -1,0 +1,49 @@
+import argparse
+import os
+import joblib
+import pandas as pd
+
+from utils import NUMERIC_COLS
+
+
+def load_models(model_dir: str = 'models'):
+    regressor = joblib.load(os.path.join(model_dir, 'regressor.joblib'))
+    classifier = joblib.load(os.path.join(model_dir, 'classifier.joblib'))
+    label_encoders = joblib.load(os.path.join(model_dir, 'label_encoders.joblib'))
+    return regressor, classifier, label_encoders
+
+
+def predict(fighter1: str, fighter2: str, referee: str,
+            regressor, classifier, label_encoders):
+    X_new = pd.DataFrame({
+        'fighter_1': [fighter1],
+        'fighter_2': [fighter2],
+        'referee': [referee]
+    })
+    num_pred = regressor.predict(X_new)[0]
+    cat_pred_codes = classifier.predict(X_new)[0]
+    cat_pred = {
+        col: label_encoders[col].inverse_transform([code])[0]
+        for col, code in zip(label_encoders, cat_pred_codes)
+    }
+    result = dict(zip(NUMERIC_COLS, num_pred))
+    result.update(cat_pred)
+    return result
+
+
+def main():
+    parser = argparse.ArgumentParser(description='Predict fight statistics and outcome')
+    parser.add_argument('--fighter1', required=True)
+    parser.add_argument('--fighter2', required=True)
+    parser.add_argument('--referee', required=True)
+    parser.add_argument('--model-dir', default='models')
+    args = parser.parse_args()
+
+    regressor, classifier, label_encoders = load_models(args.model_dir)
+    prediction = predict(args.fighter1, args.fighter2, args.referee,
+                         regressor, classifier, label_encoders)
+    print(prediction)
+
+
+if __name__ == '__main__':
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+pandas
+scikit-learn
+joblib

--- a/train.py
+++ b/train.py
@@ -1,0 +1,54 @@
+import os
+import joblib
+from sklearn.compose import ColumnTransformer
+from sklearn.ensemble import RandomForestClassifier, RandomForestRegressor
+from sklearn.model_selection import train_test_split
+from sklearn.multioutput import MultiOutputClassifier
+from sklearn.pipeline import Pipeline
+from sklearn.preprocessing import LabelEncoder, OneHotEncoder
+
+from utils import NUMERIC_COLS, load_data
+
+
+def train_models(csv_path: str, model_dir: str = 'models') -> None:
+    df = load_data(csv_path)
+    X = df[['fighter_1', 'fighter_2', 'referee']]
+    y_num = df[NUMERIC_COLS]
+    y_cat = df[['result', 'method', 'round']]
+
+    label_encoders = {}
+    for col in y_cat.columns:
+        le = LabelEncoder()
+        y_cat[col] = le.fit_transform(y_cat[col])
+        label_encoders[col] = le
+
+    preproc = ColumnTransformer([
+        ('names', OneHotEncoder(handle_unknown='ignore'), ['fighter_1', 'fighter_2', 'referee'])
+    ])
+
+    regressor = Pipeline([
+        ('prep', preproc),
+        ('rf', RandomForestRegressor(n_estimators=200, random_state=42))
+    ])
+
+    classifier = Pipeline([
+        ('prep', preproc),
+        ('rf', MultiOutputClassifier(RandomForestClassifier(n_estimators=200, random_state=42)))
+    ])
+
+    X_train, X_test, y_num_train, y_num_test, y_cat_train, y_cat_test = train_test_split(
+        X, y_num, y_cat, test_size=0.2, random_state=42
+    )
+
+    regressor.fit(X_train, y_num_train)
+    classifier.fit(X_train, y_cat_train)
+
+    os.makedirs(model_dir, exist_ok=True)
+    joblib.dump(regressor, os.path.join(model_dir, 'regressor.joblib'))
+    joblib.dump(classifier, os.path.join(model_dir, 'classifier.joblib'))
+    joblib.dump(label_encoders, os.path.join(model_dir, 'label_encoders.joblib'))
+    print(f'Models saved to {model_dir}')
+
+
+if __name__ == '__main__':
+    train_models('ufc_fight_stats.csv')

--- a/utils.py
+++ b/utils.py
@@ -1,0 +1,63 @@
+import numpy as np
+import pandas as pd
+
+# Columns containing "X of Y" counts
+COUNT_COLS = [
+    'total_strikes_1', 'total_strikes_2',
+    'significant_strikes_1', 'significant_strikes_2',
+    'head_strikes_1', 'head_strikes_2',
+    'body_strikes_1', 'body_strikes_2',
+    'leg_strikes_1', 'leg_strikes_2',
+    'distance_strikes_1', 'distance_strikes_2',
+    'clinch_strikes_1', 'clinch_strikes_2',
+    'ground_strikes_1', 'ground_strikes_2',
+    'takedowns_1', 'takedowns_2'
+]
+
+# Columns representing times in mm:ss format
+TIME_COLS = ['control_time_1', 'control_time_2', 'time']
+
+# Numeric output columns the model predicts
+NUMERIC_COLS = [
+    'knockdowns_1', 'knockdowns_2',
+    'total_strikes_1', 'total_strikes_2',
+    'significant_strikes_1', 'significant_strikes_2',
+    'head_strikes_1', 'head_strikes_2',
+    'body_strikes_1', 'body_strikes_2',
+    'leg_strikes_1', 'leg_strikes_2',
+    'distance_strikes_1', 'distance_strikes_2',
+    'clinch_strikes_1', 'clinch_strikes_2',
+    'ground_strikes_1', 'ground_strikes_2',
+    'takedowns_1', 'takedowns_2',
+    'submission_attempts_1', 'submission_attempts_2',
+    'reversals_1', 'reversals_2',
+    'control_time_1', 'control_time_2',
+    'time'
+]
+
+def parse_count(value):
+    """Return the landed count from strings like '19 of 31'."""
+    try:
+        return int(str(value).split(' of ')[0])
+    except Exception:
+        return np.nan
+
+def parse_time(ts):
+    """Convert mm:ss strings to total seconds."""
+    try:
+        m, s = map(int, str(ts).split(':'))
+        return m * 60 + s
+    except Exception:
+        return np.nan
+
+def load_data(path: str) -> pd.DataFrame:
+    """Load and clean the UFC stats dataset."""
+    df = pd.read_csv(path)
+    for col in COUNT_COLS:
+        df[col] = df[col].apply(parse_count)
+    for col in TIME_COLS:
+        df[col] = df[col].apply(parse_time)
+    numeric_cols = NUMERIC_COLS + ['round']
+    df[numeric_cols] = df[numeric_cols].apply(pd.to_numeric, errors='coerce').fillna(0)
+    df['round'] = df['round'].astype(int)
+    return df


### PR DESCRIPTION
## Summary
- add utility functions for parsing UFC statistics and time strings
- implement a training script that saves random forest models
- provide a prediction script for loading the saved models
- document setup, training, and prediction steps

## Testing
- `python train.py`
- `python predict.py --fighter1 "Alexa Grasso" --fighter2 "Valentina Shevchenko" --referee "Herb Dean"`


------
https://chatgpt.com/codex/tasks/task_e_689d222e08148330bf16f60aa3efd610