### PR TITLE
Add optional CUDA support for training and inference

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,14 +12,14 @@ pip install -r requirements.txt
 Train models and save them to the `models/` directory:
 
 ```
-python train.py
+python train.py [--use-cuda]
 ```
 
 ## Prediction
 Load the saved models and generate predictions for a matchup:
 
 ```
-python predict.py --fighter1 "Alexa Grasso" --fighter2 "Valentina Shevchenko" --referee "Herb Dean"
+python predict.py --fighter1 "Alexa Grasso" --fighter2 "Valentina Shevchenko" --referee "Herb Dean" [--use-cuda]
 ```
 
 The script prints predicted fight statistics along with the result, method and round.

--- a/predict.py
+++ b/predict.py
@@ -14,17 +14,32 @@ def load_models(model_dir: str = 'models'):
 
 
 def predict(fighter1: str, fighter2: str, referee: str,
-            regressor, classifier, label_encoders):
+            regressor, classifier, label_encoders, use_cuda: bool = False):
     X_new = pd.DataFrame({
         'fighter_1': [fighter1],
         'fighter_2': [fighter2],
         'referee': [referee]
     })
-    num_pred = regressor.predict(X_new)[0]
-    cat_pred_codes = classifier.predict(X_new)[0]
+
+    def _to_numpy(arr):
+        """Convert cupy/cudf objects to numpy arrays."""
+        if hasattr(arr, 'to_pandas'):
+            arr = arr.to_pandas().to_numpy()
+        if hasattr(arr, 'get'):
+            arr = arr.get()
+        return arr
+
+    num_pred = _to_numpy(regressor.predict(X_new))[0]
+    num_pred = [float(x) for x in num_pred]
+    cat_pred_codes = _to_numpy(classifier.predict(X_new))[0]
+    cat_pred_codes = [int(x) for x in cat_pred_codes]
     cat_pred = {
         col: label_encoders[col].inverse_transform([code])[0]
         for col, code in zip(label_encoders, cat_pred_codes)
+    }
+    cat_pred = {
+        col: int(val) if hasattr(val, 'item') and isinstance(val.item(), int) else val
+        for col, val in cat_pred.items()
     }
     result = dict(zip(NUMERIC_COLS, num_pred))
     result.update(cat_pred)
@@ -37,11 +52,14 @@ def main():
     parser.add_argument('--fighter2', required=True)
     parser.add_argument('--referee', required=True)
     parser.add_argument('--model-dir', default='models')
+    parser.add_argument('--use-cuda', action='store_true',
+                        help='Use GPU-accelerated models if available')
     args = parser.parse_args()
 
     regressor, classifier, label_encoders = load_models(args.model_dir)
     prediction = predict(args.fighter1, args.fighter2, args.referee,
-                         regressor, classifier, label_encoders)
+                         regressor, classifier, label_encoders,
+                         use_cuda=args.use_cuda)
     print(prediction)
 
 


### PR DESCRIPTION
## Summary
- Add `_get_estimators` helper to use cuML RandomForest when `--use-cuda` is set, falling back to scikit-learn otherwise
- Extend `predict` to handle cuML outputs and expose a `--use-cuda` flag
- Document optional CUDA usage in README

## Testing
- `python train.py --csv-path ufc_fight_stats.csv --model-dir models_test`
- `python predict.py --fighter1 "Alexa Grasso" --fighter2 "Valentina Shevchenko" --referee "Herb Dean" --model-dir models_test`


------
https://chatgpt.com/codex/tasks/task_e_689df6ec266083309651dad4facd4015