### PR TITLE
Add cuML dependency and copy DataFrame slices

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ pandas
 scikit-learn
 joblib
 tensorboardX
+cuml

--- a/train.py
+++ b/train.py
@@ -44,9 +44,10 @@ def train_models(csv_path: str, model_dir: str = 'models', epochs: int = 1, use_
     """
 
     df = load_data(csv_path)
-    X = df[['fighter_1', 'fighter_2', 'referee']]
-    y_num = df[NUMERIC_COLS]
-    y_cat = df[['result', 'method', 'round']]
+    # create explicit copies to avoid SettingWithCopyWarning when modifying
+    X = df[['fighter_1', 'fighter_2', 'referee']].copy()
+    y_num = df[NUMERIC_COLS].copy()
+    y_cat = df[['result', 'method', 'round']].copy()
 
     label_encoders = {}
     for col in y_cat.columns:


### PR DESCRIPTION
## Summary
- add cuML to Python requirements for optional GPU-accelerated training
- copy DataFrame slices in training script to avoid pandas SettingWithCopyWarning

## Testing
- `python3 -m py_compile train.py`
- `python3 train.py --epochs 1` *(interrupted due to long runtime)*

------
https://chatgpt.com/codex/tasks/task_e_689dfe05c9a48330847d8871978bf74f