### PR TITLE
Switch to TensorFlow Decision Forests and TensorBoard logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 Using Tabular UFC fight data to predict winners from a given matchup
 
 ## Model Overview
-The training pipeline cleans raw fight statistics (for example converting "19 of 31" and "2:39" to numbers) and one-hot encodes fighter and referee names. It builds two Random Forest models with 200 trees each: a `RandomForestRegressor` that predicts multiple numeric fight stats and a `MultiOutputClassifier` wrapping a `RandomForestClassifier` that predicts the fight result, method and round. All models and label encoders are saved so that, during prediction, the script loads them, assembles a one-row DataFrame for the matchup, translates predictions back to labels and returns a combined dictionary of fight statistics and outcome.
+The training pipeline cleans raw fight statistics (for example converting "19 of 31" and "2:39" to numbers) and feeds fighter and referee names directly into [TensorFlow Decision Forests](https://www.tensorflow.org/decision_forests). Separate Random Forest models predict numeric fight statistics and categorical outcomes (result, method and round). Models are saved in TensorFlow's SavedModel format for use during prediction.
 
 ## Setup
 Install dependencies:
@@ -15,7 +15,7 @@ pip install -r requirements.txt
 Train models and save them to the `models/` directory:
 
 ```
-python train.py [--use-cuda]
+python train.py
 ```
 
 You can adjust the number of epochs and data/model paths:
@@ -35,7 +35,7 @@ tensorboard --logdir runs
 Load the saved models and generate predictions for a matchup:
 
 ```
-python predict.py --fighter1 "Alexa Grasso" --fighter2 "Valentina Shevchenko" --referee "Herb Dean" [--use-cuda]
+python predict.py --fighter1 "Alexa Grasso" --fighter2 "Valentina Shevchenko" --referee "Herb Dean"
 ```
 
 The script prints predicted fight statistics along with the result, method and round.

--- a/predict.py
+++ b/predict.py
@@ -1,47 +1,49 @@
 import argparse
+import json
 import os
-import joblib
 import pandas as pd
+import tensorflow as tf
+import tensorflow_decision_forests as tfdf
 
 from utils import NUMERIC_COLS
 
 
 def load_models(model_dir: str = 'models'):
-    regressor = joblib.load(os.path.join(model_dir, 'regressor.joblib'))
-    classifier = joblib.load(os.path.join(model_dir, 'classifier.joblib'))
-    label_encoders = joblib.load(os.path.join(model_dir, 'label_encoders.joblib'))
-    return regressor, classifier, label_encoders
+    regressors = {}
+    for col in NUMERIC_COLS:
+        path = os.path.join(model_dir, f'regressor_{col}')
+        regressors[col] = tf.keras.models.load_model(path)
+    classifiers = {}
+    for col in ['result', 'method', 'round']:
+        path = os.path.join(model_dir, f'classifier_{col}')
+        classifiers[col] = tf.keras.models.load_model(path)
+    with open(os.path.join(model_dir, 'class_info.json')) as f:
+        class_info = json.load(f)
+    return regressors, classifiers, class_info
 
 
 def predict(fighter1: str, fighter2: str, referee: str,
-            regressor, classifier, label_encoders, use_cuda: bool = False):
+            regressors, classifiers, class_info):
     X_new = pd.DataFrame({
         'fighter_1': [fighter1],
         'fighter_2': [fighter2],
         'referee': [referee]
     })
-
-    def _to_numpy(arr):
-        """Convert cupy/cudf objects to numpy arrays."""
-        if hasattr(arr, 'to_pandas'):
-            arr = arr.to_pandas().to_numpy()
-        if hasattr(arr, 'get'):
-            arr = arr.get()
-        return arr
-
-    num_pred = _to_numpy(regressor.predict(X_new))[0]
-    num_pred = [float(x) for x in num_pred]
-    cat_pred_codes = _to_numpy(classifier.predict(X_new))[0]
-    cat_pred_codes = [int(x) for x in cat_pred_codes]
-    cat_pred = {
-        col: label_encoders[col].inverse_transform([code])[0]
-        for col, code in zip(label_encoders, cat_pred_codes)
+    ds = tfdf.keras.pd_dataframe_to_tf_dataset(X_new)
+    num_pred = {
+        col: float(model.predict(ds)[0][0])
+        for col, model in regressors.items()
     }
-    cat_pred = {
-        col: int(val) if hasattr(val, 'item') and isinstance(val.item(), int) else val
-        for col, val in cat_pred.items()
-    }
-    result = dict(zip(NUMERIC_COLS, num_pred))
+    cat_pred = {}
+    for col, model in classifiers.items():
+        proba = model.predict(ds)[0]
+        classes = class_info[col]
+        if proba.ndim == 0 or len(proba) == 1:
+            pred = classes[1] if float(proba[0]) >= 0.5 else classes[0]
+        else:
+            pred = classes[int(proba.argmax())]
+        cat_pred[col] = pred
+    result = dict(num_pred)
     result.update(cat_pred)
     return result
 
@@ -52,14 +54,11 @@ def main():
     parser.add_argument('--fighter2', required=True)
     parser.add_argument('--referee', required=True)
     parser.add_argument('--model-dir', default='models')
-    parser.add_argument('--use-cuda', action='store_true',
-                        help='Use GPU-accelerated models if available')
     args = parser.parse_args()
 
-    regressor, classifier, label_encoders = load_models(args.model_dir)
+    regressors, classifiers, class_info = load_models(args.model_dir)
     prediction = predict(args.fighter1, args.fighter2, args.referee,
-                         regressor, classifier, label_encoders,
-                         use_cuda=args.use_cuda)
+                         regressors, classifiers, class_info)
     print(prediction)
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,3 @@
 pandas
-scikit-learn
-joblib
-tensorboardX
-cuml
+tensorflow
+tensorflow_decision_forests


### PR DESCRIPTION
## Summary
- replace scikit-learn models with TensorFlow Decision Forests and add TensorBoard logging
- update prediction pipeline to load TF models and map categorical outputs
- streamline requirements to only pandas, tensorflow, and tensorflow_decision_forests

## Testing
- `python -m py_compile train.py predict.py`
- `python train.py --epochs 1 --csv-path ufc_fight_stats.csv --model-dir models_test` *(failed: KeyboardInterrupt during long training, see tail of log)*

------
https://chatgpt.com/codex/tasks/task_e_689e12d852b88330a82001fc59e78ae1