### PR TITLE
Pin dependency versions for TensorFlow Decision Forests

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Using Tabular UFC fight data to predict winners from a given matchup
 The training pipeline cleans raw fight statistics (for example converting "19 of 31" and "2:39" to numbers) and feeds fighter and referee names directly into [TensorFlow Decision Forests](https://www.tensorflow.org/decision_forests). Separate Random Forest models predict numeric fight statistics and categorical outcomes (result, method and round). Models are saved in TensorFlow's SavedModel format for use during prediction.
 
 ## Setup
-Install dependencies:
+Install dependencies (pinned to versions compatible with TensorFlow Decision Forests):
 
 ```
 pip install -r requirements.txt

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,5 @@
-pandas
-tensorflow
+pandas<2
+numpy<2
+scipy<1.11
+tensorflow<2.16
 tensorflow_decision_forests


### PR DESCRIPTION
## Summary
- pin numpy, pandas, and scipy versions to avoid incompatibility with TensorFlow Decision Forests
- document pinned dependencies in README

## Testing
- `pip install --prefer-binary -r requirements.txt` *(fails: Getting requirements to build wheel: finished with status 'canceled')*


------
https://chatgpt.com/codex/tasks/task_e_689e1992f40c83309a52cbd7dfc85c37