### PR TITLE
Add progress bar for training epochs

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,14 +18,13 @@ Train models and save them to the `models/` directory:
 python train.py
 ```
 
-You can adjust the number of epochs and data/model paths:
+A progress bar tracks epoch progress at all debug levels. To log per-epoch metrics while keeping the bar intact, increase the debug level:
 
 ```
-python train.py --epochs 5 --csv-path ufc_fight_stats.csv --model-dir models
+python train.py --epochs 5 --debuglevel 1 --csv-path ufc_fight_stats.csv --model-dir models
 ```
 
-Training logs, including per-epoch accuracy, are written for TensorBoard. To
-visualize them, run:
+Training logs, including per-epoch accuracy, are written for TensorBoard. To visualize them, run:
 
 ```
 tensorboard --logdir runs

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
-pandas<2
 numpy<2
+pandas<2
 scipy<1.11
 tensorflow<2.16
 tensorflow_decision_forests
+tqdm

--- a/train.py
+++ b/train.py
@@ -6,6 +6,7 @@ os.environ["TF_CPP_MIN_LOG_LEVEL"] = "3"  # Reduce TensorFlow logging
 import tensorflow as tf
 import tensorflow_decision_forests as tfdf
 from absl import logging as absl_logging
+from tqdm.auto import tqdm
 
 from utils import NUMERIC_COLS, load_data, launch_tensorboard
 
@@ -31,7 +32,7 @@ def train_models(csv_path: str, model_dir: str = 'models', epochs: int = 1, debu
     writer = tf.summary.create_file_writer('runs')
     os.makedirs(model_dir, exist_ok=True)
 
-    for epoch in range(1, epochs + 1):
+    for epoch in tqdm(range(1, epochs + 1), desc="Epochs", unit="epoch"):
         train_mses, test_mses = [], []
         train_accs, test_accs = [], []
 
@@ -89,7 +90,7 @@ def train_models(csv_path: str, model_dir: str = 'models', epochs: int = 1, debu
         avg_test_mse = sum(test_mses) / len(test_mses) if test_mses else 0.0
 
         if debuglevel >= 1:
-            print(
+            tqdm.write(
                 f"Epoch {epoch}/{epochs} - Train Acc: {avg_train_acc:.4f} Test Acc: {avg_test_acc:.4f} "
                 f"Train MSE: {avg_train_mse:.4f} Test MSE: {avg_test_mse:.4f}"
             )
@@ -100,7 +101,7 @@ def train_models(csv_path: str, model_dir: str = 'models', epochs: int = 1, debu
             tf.summary.scalar('MSE/test', avg_test_mse, step=epoch)
     writer.close()
     if debuglevel >= 1:
-        print(f'Models saved to {model_dir}')
+        tqdm.write(f'Models saved to {model_dir}')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary
- show progress through training epochs with a new tqdm progress bar
- log metrics via `tqdm.write` to keep progress bar intact
- add `tqdm` dependency and document usage in README

## Testing
- `python -m py_compile train.py`
- `python train.py --epochs 1 --debuglevel 0 --csv-path ufc_fight_stats.csv` *(fails: ModuleNotFoundError: No module named 'tensorflow')*


------
https://chatgpt.com/codex/tasks/task_e_689e2ed0ee008330a876c4be7b12ac60