### PR TITLE
feat: add optional CUDA support

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,9 @@ Using Tabular UFC fight data to predict winners from a given matchup
 The training pipeline cleans raw fight statistics (for example converting "19 of 31" and "2:39" to numbers) and feeds fighter and referee names directly into [TensorFlow Decision Forests](https://www.tensorflow.org/decision_forests). Separate Random Forest models predict numeric fight statistics and categorical outcomes (result, method and round). Models are saved in TensorFlow's SavedModel format for use during prediction.
 
 ## Setup
-Install dependencies (pinned to versions compatible with TensorFlow Decision Forests):
+Install dependencies (pinned to versions compatible with TensorFlow Decision Forests).
+The requirements include optional CUDA-enabled TensorFlow; if a compatible GPU and
+drivers are present, training and prediction will automatically leverage it:
 
 ```
 pip install -r requirements.txt

--- a/predict.py
+++ b/predict.py
@@ -8,7 +8,7 @@ import pandas as pd
 import tensorflow as tf
 import tensorflow_decision_forests as tfdf
 
-from utils import NUMERIC_COLS, launch_tensorboard
+from utils import NUMERIC_COLS, launch_tensorboard, configure_device
 
 
 def load_models(model_dir: str = 'models'):
@@ -59,6 +59,7 @@ def main():
     parser.add_argument('--model-dir', default='models')
     args = parser.parse_args()
 
+    configure_device()
     launch_tensorboard('runs')
     regressors, classifiers, class_info = load_models(args.model_dir)
     prediction = predict(args.fighter1, args.fighter2, args.referee,

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 numpy<2
 pandas<2
 scipy<1.11
-tensorflow<2.16
+tensorflow[and-cuda]<2.16
 tensorflow_decision_forests
 tqdm

--- a/train.py
+++ b/train.py
@@ -8,11 +8,12 @@ import tensorflow_decision_forests as tfdf
 from absl import logging as absl_logging
 from tqdm.auto import tqdm
 
-from utils import NUMERIC_COLS, load_data, launch_tensorboard
+from utils import NUMERIC_COLS, load_data, launch_tensorboard, configure_device
 
 
 def train_models(csv_path: str, model_dir: str = 'models', epochs: int = 1, debuglevel: int = 0) -> None:
     """Train TensorFlow Decision Forest models and log metrics to TensorBoard."""
+    configure_device()
     if debuglevel >= 2:
         tf.get_logger().setLevel("INFO")
         absl_logging.set_verbosity(absl_logging.INFO)

--- a/utils.py
+++ b/utils.py
@@ -1,5 +1,6 @@
 import numpy as np
 import pandas as pd
+import tensorflow as tf
 
 # Columns containing "X of Y" counts
 COUNT_COLS = [
@@ -74,3 +75,18 @@ def launch_tensorboard(log_dir: str = 'runs') -> None:
         print(f'TensorBoard started at {url}')
     except Exception as e:
         print(f'Failed to launch TensorBoard: {e}')
+
+
+def configure_device() -> None:
+    """Enable GPU acceleration if a compatible device is available."""
+    gpus = tf.config.list_physical_devices('GPU')
+    if not gpus:
+        print('No GPU detected. Using CPU.')
+        return
+    try:
+        for gpu in gpus:
+            tf.config.experimental.set_memory_growth(gpu, True)
+        gpu_names = ', '.join([gpu.name for gpu in gpus])
+        print(f'Enabled GPU acceleration on: {gpu_names}')
+    except RuntimeError as e:
+        print(f'Failed to configure GPU: {e}')


### PR DESCRIPTION
## Summary
- add utility to configure GPU devices and enable memory growth
- automatically enable GPU when available for training and prediction
- switch to CUDA-enabled TensorFlow dependency and document GPU usage

## Testing
- `python -m py_compile utils.py train.py predict.py`
- `pip install -r requirements.txt` *(fails: Operation cancelled by user)*

------
https://chatgpt.com/codex/tasks/task_e_689e31a083d08330a72aa8f3dac67ecb