### PR TITLE
Pin TensorFlow version for TF-DF compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Using Tabular UFC fight data to predict winners from a given matchup
 The training pipeline cleans raw fight statistics (for example converting "19 of 31" and "2:39" to numbers) and feeds fighter and referee names directly into [TensorFlow Decision Forests](https://www.tensorflow.org/decision_forests). Separate Random Forest models predict numeric fight statistics and categorical outcomes (result, method and round). Models are saved in TensorFlow's SavedModel format for use during prediction.
 
 ## Setup
-Install dependencies (pinned to versions compatible with TensorFlow Decision Forests).
+Install dependencies (TensorFlow 2.15.0 and TensorFlow Decision Forests 1.8.1 are pinned for compatibility).
 The requirements include optional CUDA-enabled TensorFlow; if a compatible GPU and
 drivers are present, training and prediction will automatically leverage it:
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 numpy<2
 pandas<2
 scipy<1.11
-tensorflow[and-cuda]<2.16
-tensorflow_decision_forests
+tensorflow[and-cuda]==2.15.0
+tensorflow_decision_forests==1.8.1
 tqdm


### PR DESCRIPTION
## Summary
- Pin TensorFlow to 2.15.0 and TensorFlow Decision Forests to 1.8.1 to avoid segfaults.
- Document pinned versions in README.

## Testing
- `python -m py_compile train.py predict.py utils.py`
- `pip install -r requirements.txt` *(fails: Getting requirements to build wheel: finished with status 'canceled')*

------
https://chatgpt.com/codex/tasks/task_e_689e3a5a82f88330ad5059d46ac764bc