### PR TITLE
Switch to scikit-learn and remove TensorBoard

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,12 +2,10 @@
 Using Tabular UFC fight data to predict winners from a given matchup
 
 ## Model Overview
-The training pipeline cleans raw fight statistics (for example converting "19 of 31" and "2:39" to numbers) and feeds fighter and referee names directly into [TensorFlow Decision Forests](https://www.tensorflow.org/decision_forests). Separate Random Forest models predict numeric fight statistics and categorical outcomes (result, method and round). Models are saved in TensorFlow's SavedModel format for use during prediction.
+The training pipeline cleans raw fight statistics (for example converting "19 of 31" and "2:39" to numbers) and encodes fighter and referee names for use with [scikit-learn](https://scikit-learn.org/). Separate Random Forest models predict numeric fight statistics and categorical outcomes (result, method and round). Models and the feature encoder are saved with `joblib` for later prediction.
 
 ## Setup
-Install dependencies (TensorFlow 2.15.0 and TensorFlow Decision Forests 1.8.1 are pinned for compatibility).
-The requirements include optional CUDA-enabled TensorFlow; if a compatible GPU and
-drivers are present, training and prediction will automatically leverage it:
+Install dependencies:
 
 ```
 pip install -r requirements.txt
@@ -17,20 +15,17 @@ pip install -r requirements.txt
 Train models and save them to the `models/` directory:
 
 ```
-python train.py
+python train.py --csv-path ufc_fight_stats.csv --model-dir models
 ```
 
-A progress bar tracks epoch progress at all debug levels. To log per-epoch metrics while keeping the bar intact, increase the debug level:
+### Configurable Parameters
+The training script exposes several arguments that can improve accuracy and precision:
 
-```
-python train.py --epochs 5 --debuglevel 1 --csv-path ufc_fight_stats.csv --model-dir models
-```
+* `--n-estimators` – number of trees in each forest (default: 100)
+* `--max-depth` – maximum depth of each tree (default: unlimited)
+* `--random-state` – seed for reproducible splits and model initialization (default: 42)
 
-Training logs, including per-epoch accuracy, are written for TensorBoard. To visualize them, run:
-
-```
-tensorboard --logdir runs
-```
+Tune these parameters to balance bias and variance for your dataset.
 
 ## Prediction
 Load the saved models and generate predictions for a matchup:

--- a/predict.py
+++ b/predict.py
@@ -1,71 +1,52 @@
 import argparse
-import json
 import os
 
-os.environ["TF_CPP_MIN_LOG_LEVEL"] = "3"
-
+import joblib
 import pandas as pd
-import tensorflow as tf
-import tensorflow_decision_forests as tfdf
 
-from utils import NUMERIC_COLS, launch_tensorboard, configure_device
+from utils import NUMERIC_COLS
 
 
-def load_models(model_dir: str = 'models'):
-    regressors = {}
-    for col in NUMERIC_COLS:
-        path = os.path.join(model_dir, f'regressor_{col}')
-        regressors[col] = tf.keras.models.load_model(path)
-    classifiers = {}
-    for col in ['result', 'method', 'round']:
-        path = os.path.join(model_dir, f'classifier_{col}')
-        classifiers[col] = tf.keras.models.load_model(path)
-    with open(os.path.join(model_dir, 'class_info.json')) as f:
-        class_info = json.load(f)
-    return regressors, classifiers, class_info
-
-
-def predict(fighter1: str, fighter2: str, referee: str,
-            regressors, classifiers, class_info):
-    X_new = pd.DataFrame({
-        'fighter_1': [fighter1],
-        'fighter_2': [fighter2],
-        'referee': [referee]
-    })
-    ds = tfdf.keras.pd_dataframe_to_tf_dataset(X_new)
-    num_pred = {
-        col: float(model.predict(ds)[0][0])
-        for col, model in regressors.items()
+def load_models(model_dir: str = "models"):
+    encoder = joblib.load(os.path.join(model_dir, "encoder.joblib"))
+    regressors = {
+        col: joblib.load(os.path.join(model_dir, f"regressor_{col}.joblib"))
+        for col in NUMERIC_COLS
     }
-    cat_pred = {}
-    for col, model in classifiers.items():
-        proba = model.predict(ds)[0]
-        classes = class_info[col]
-        if proba.ndim == 0 or len(proba) == 1:
-            pred = classes[1] if float(proba[0]) >= 0.5 else classes[0]
-        else:
-            pred = classes[int(proba.argmax())]
-        cat_pred[col] = pred
+    classifiers = {
+        col: joblib.load(os.path.join(model_dir, f"classifier_{col}.joblib"))
+        for col in ["result", "method", "round"]
+    }
+    return encoder, regressors, classifiers
+
+
+def predict(fighter1: str, fighter2: str, referee: str, encoder, regressors, classifiers):
+    X_new = pd.DataFrame(
+        {"fighter_1": [fighter1], "fighter_2": [fighter2], "referee": [referee]}
+    )
+    X = encoder.transform(X_new)
+    num_pred = {col: float(model.predict(X)[0]) for col, model in regressors.items()}
+    cat_pred = {col: model.predict(X)[0] for col, model in classifiers.items()}
     result = dict(num_pred)
     result.update(cat_pred)
     return result
 
 
 def main():
-    parser = argparse.ArgumentParser(description='Predict fight statistics and outcome')
-    parser.add_argument('--fighter1', required=True)
-    parser.add_argument('--fighter2', required=True)
-    parser.add_argument('--referee', required=True)
-    parser.add_argument('--model-dir', default='models')
+    parser = argparse.ArgumentParser(description="Predict fight statistics and outcome")
+    parser.add_argument("--fighter1", required=True)
+    parser.add_argument("--fighter2", required=True)
+    parser.add_argument("--referee", required=True)
+    parser.add_argument("--model-dir", default="models")
     args = parser.parse_args()
 
-    configure_device()
-    launch_tensorboard('runs')
-    regressors, classifiers, class_info = load_models(args.model_dir)
-    prediction = predict(args.fighter1, args.fighter2, args.referee,
-                         regressors, classifiers, class_info)
+    encoder, regressors, classifiers = load_models(args.model_dir)
+    prediction = predict(
+        args.fighter1, args.fighter2, args.referee, encoder, regressors, classifiers
+    )
     print(prediction)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,5 @@
 numpy<2
 pandas<2
-scipy<1.11
-tensorflow[and-cuda]==2.15.0
-tensorflow_decision_forests==1.8.1
+scikit-learn
+joblib
 tqdm

--- a/train.py
+++ b/train.py
@@ -1,119 +1,106 @@
 import os
-import json
+from typing import Optional
 
-os.environ["TF_CPP_MIN_LOG_LEVEL"] = "3"  # Reduce TensorFlow logging
-
-import tensorflow as tf
-import tensorflow_decision_forests as tfdf
-from absl import logging as absl_logging
+import joblib
 from tqdm.auto import tqdm
+from sklearn.ensemble import RandomForestRegressor, RandomForestClassifier
+from sklearn.metrics import mean_squared_error, accuracy_score
+from sklearn.preprocessing import OneHotEncoder
 
-from utils import NUMERIC_COLS, load_data, launch_tensorboard, configure_device
+from utils import NUMERIC_COLS, load_data
 
 
-def train_models(csv_path: str, model_dir: str = 'models', epochs: int = 1, debuglevel: int = 0) -> None:
-    """Train TensorFlow Decision Forest models and log metrics to TensorBoard."""
-    configure_device()
-    if debuglevel >= 2:
-        tf.get_logger().setLevel("INFO")
-        absl_logging.set_verbosity(absl_logging.INFO)
-        absl_logging.set_stderrthreshold('info')
-    else:
-        tf.get_logger().setLevel("ERROR")
-        absl_logging.set_verbosity(absl_logging.ERROR)
-        absl_logging.set_stderrthreshold('error')
-    launch_tensorboard("runs")
+def train_models(
+    csv_path: str,
+    model_dir: str = "models",
+    n_estimators: int = 100,
+    max_depth: Optional[int] = None,
+    random_state: int = 42,
+) -> None:
+    """Train scikit-learn Random Forest models for fight statistics and outcomes."""
+
     df = load_data(csv_path)
-    features = ['fighter_1', 'fighter_2', 'referee']
-    df_shuffled = df.sample(frac=1, random_state=42)
+    features = ["fighter_1", "fighter_2", "referee"]
+    df_shuffled = df.sample(frac=1, random_state=random_state).reset_index(drop=True)
     split = int(len(df_shuffled) * 0.8)
-    train_df = df_shuffled.iloc[:split].reset_index(drop=True)
-    test_df = df_shuffled.iloc[split:].reset_index(drop=True)
+    train_df = df_shuffled.iloc[:split]
+    test_df = df_shuffled.iloc[split:]
 
-    writer = tf.summary.create_file_writer('runs')
+    encoder = OneHotEncoder(handle_unknown="ignore")
+    encoder.fit(train_df[features])
+
     os.makedirs(model_dir, exist_ok=True)
+    joblib.dump(encoder, os.path.join(model_dir, "encoder.joblib"))
 
-    for epoch in tqdm(range(1, epochs + 1), desc="Epochs", unit="epoch"):
-        train_mses, test_mses = [], []
-        train_accs, test_accs = [], []
+    X_train = encoder.transform(train_df[features])
+    X_test = encoder.transform(test_df[features])
 
-        # Train regressors for numeric columns
-        for col in NUMERIC_COLS:
-            train_ds = tfdf.keras.pd_dataframe_to_tf_dataset(
-                train_df[features + [col]], label=col, task=tfdf.keras.Task.REGRESSION
-            )
-            test_ds = tfdf.keras.pd_dataframe_to_tf_dataset(
-                test_df[features + [col]], label=col, task=tfdf.keras.Task.REGRESSION
-            )
-            model = tfdf.keras.RandomForestModel(
-                task=tfdf.keras.Task.REGRESSION, num_trees=100, verbose=0
-            )
-            fit_verbose = 1 if debuglevel >= 2 else 0
-            model.fit(train_ds, verbose=fit_verbose)
-            model.compile(metrics=['mse'])
-            eval_verbose = 1 if debuglevel >= 2 else 0
-            train_eval = model.evaluate(train_ds, return_dict=True, verbose=eval_verbose)
-            test_eval = model.evaluate(test_ds, return_dict=True, verbose=eval_verbose)
-            train_mses.append(train_eval['mse'])
-            test_mses.append(test_eval['mse'])
-            model.save(os.path.join(model_dir, f'regressor_{col}'))
+    train_mses, test_mses = [], []
+    train_accs, test_accs = [], []
 
-        # Train classifiers for categorical columns
-        class_info = {}
-        for col in ['result', 'method', 'round']:
-            classes = sorted(train_df[col].unique().tolist())
-            class_info[col] = classes
-            train_ds = tfdf.keras.pd_dataframe_to_tf_dataset(
-                train_df[features + [col]], label=col, task=tfdf.keras.Task.CLASSIFICATION
-            )
-            test_ds = tfdf.keras.pd_dataframe_to_tf_dataset(
-                test_df[features + [col]], label=col, task=tfdf.keras.Task.CLASSIFICATION
-            )
-            model = tfdf.keras.RandomForestModel(
-                task=tfdf.keras.Task.CLASSIFICATION, num_trees=100, verbose=0
-            )
-            fit_verbose = 1 if debuglevel >= 2 else 0
-            model.fit(train_ds, verbose=fit_verbose)
-            model.compile(metrics=['accuracy'])
-            eval_verbose = 1 if debuglevel >= 2 else 0
-            train_eval = model.evaluate(train_ds, return_dict=True, verbose=eval_verbose)
-            test_eval = model.evaluate(test_ds, return_dict=True, verbose=eval_verbose)
-            train_accs.append(train_eval['accuracy'])
-            test_accs.append(test_eval['accuracy'])
-            model.save(os.path.join(model_dir, f'classifier_{col}'))
+    # Train regressors for numeric columns
+    for col in tqdm(NUMERIC_COLS, desc="Regressors"):
+        model = RandomForestRegressor(
+            n_estimators=n_estimators,
+            max_depth=max_depth,
+            random_state=random_state,
+            n_jobs=-1,
+        )
+        model.fit(X_train, train_df[col])
+        train_pred = model.predict(X_train)
+        test_pred = model.predict(X_test)
+        train_mses.append(mean_squared_error(train_df[col], train_pred))
+        test_mses.append(mean_squared_error(test_df[col], test_pred))
+        joblib.dump(model, os.path.join(model_dir, f"regressor_{col}.joblib"))
 
-        with open(os.path.join(model_dir, 'class_info.json'), 'w') as f:
-            json.dump(class_info, f)
+    # Train classifiers for categorical columns
+    for col in tqdm(["result", "method", "round"], desc="Classifiers"):
+        model = RandomForestClassifier(
+            n_estimators=n_estimators,
+            max_depth=max_depth,
+            random_state=random_state,
+            n_jobs=-1,
+        )
+        model.fit(X_train, train_df[col])
+        train_pred = model.predict(X_train)
+        test_pred = model.predict(X_test)
+        train_accs.append(accuracy_score(train_df[col], train_pred))
+        test_accs.append(accuracy_score(test_df[col], test_pred))
+        joblib.dump(model, os.path.join(model_dir, f"classifier_{col}.joblib"))
 
-        avg_train_acc = sum(train_accs) / len(train_accs) if train_accs else 0.0
-        avg_test_acc = sum(test_accs) / len(test_accs) if test_accs else 0.0
-        avg_train_mse = sum(train_mses) / len(train_mses) if train_mses else 0.0
-        avg_test_mse = sum(test_mses) / len(test_mses) if test_mses else 0.0
+    avg_train_acc = sum(train_accs) / len(train_accs) if train_accs else 0.0
+    avg_test_acc = sum(test_accs) / len(test_accs) if test_accs else 0.0
+    avg_train_mse = sum(train_mses) / len(train_mses) if train_mses else 0.0
+    avg_test_mse = sum(test_mses) / len(test_mses) if test_mses else 0.0
 
-        if debuglevel >= 1:
-            tqdm.write(
-                f"Epoch {epoch}/{epochs} - Train Acc: {avg_train_acc:.4f} Test Acc: {avg_test_acc:.4f} "
-                f"Train MSE: {avg_train_mse:.4f} Test MSE: {avg_test_mse:.4f}"
-            )
-        with writer.as_default():
-            tf.summary.scalar('Accuracy/train', avg_train_acc, step=epoch)
-            tf.summary.scalar('Accuracy/test', avg_test_acc, step=epoch)
-            tf.summary.scalar('MSE/train', avg_train_mse, step=epoch)
-            tf.summary.scalar('MSE/test', avg_test_mse, step=epoch)
-    writer.close()
-    if debuglevel >= 1:
-        tqdm.write(f'Models saved to {model_dir}')
+    print(
+        f"Train Acc: {avg_train_acc:.4f} Test Acc: {avg_test_acc:.4f} "
+        f"Train MSE: {avg_train_mse:.4f} Test MSE: {avg_test_mse:.4f}"
+    )
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     import argparse
 
-    parser = argparse.ArgumentParser(description='Train fight outcome models')
-    parser.add_argument('--csv-path', default='ufc_fight_stats.csv')
-    parser.add_argument('--model-dir', default='models')
-    parser.add_argument('--epochs', type=int, default=1, help='Number of training epochs')
-    parser.add_argument('--debuglevel', type=int, default=0, choices=[0, 1, 2],
-                        help='0=silent, 1=metrics, 2=verbose')
+    parser = argparse.ArgumentParser(description="Train fight outcome models")
+    parser.add_argument("--csv-path", default="ufc_fight_stats.csv")
+    parser.add_argument("--model-dir", default="models")
+    parser.add_argument(
+        "--n-estimators", type=int, default=100, help="Number of trees in each forest"
+    )
+    parser.add_argument(
+        "--max-depth", type=int, default=None, help="Maximum depth of each tree"
+    )
+    parser.add_argument(
+        "--random-state", type=int, default=42, help="Random seed for reproducibility"
+    )
     args = parser.parse_args()
 
-    train_models(args.csv_path, args.model_dir, epochs=args.epochs, debuglevel=args.debuglevel)
+    train_models(
+        args.csv_path,
+        args.model_dir,
+        n_estimators=args.n_estimators,
+        max_depth=args.max_depth,
+        random_state=args.random_state,
+    )
+

--- a/utils.py
+++ b/utils.py
@@ -1,6 +1,5 @@
 import numpy as np
 import pandas as pd
-import tensorflow as tf
 
 # Columns containing "X of Y" counts
 COUNT_COLS = [
@@ -62,31 +61,3 @@ def load_data(path: str) -> pd.DataFrame:
     df[numeric_cols] = df[numeric_cols].apply(pd.to_numeric, errors='coerce').fillna(0)
     df['round'] = df['round'].astype(int)
     return df
-
-
-def launch_tensorboard(log_dir: str = 'runs') -> None:
-    """Start a TensorBoard server for visualizing training metrics."""
-    try:
-        from tensorboard import program
-
-        tb = program.TensorBoard()
-        tb.configure(argv=[None, '--logdir', log_dir, '--host', '0.0.0.0'])
-        url = tb.launch()
-        print(f'TensorBoard started at {url}')
-    except Exception as e:
-        print(f'Failed to launch TensorBoard: {e}')
-
-
-def configure_device() -> None:
-    """Enable GPU acceleration if a compatible device is available."""
-    gpus = tf.config.list_physical_devices('GPU')
-    if not gpus:
-        print('No GPU detected. Using CPU.')
-        return
-    try:
-        for gpu in gpus:
-            tf.config.experimental.set_memory_growth(gpu, True)
-        gpu_names = ', '.join([gpu.name for gpu in gpus])
-        print(f'Enabled GPU acceleration on: {gpu_names}')
-    except RuntimeError as e:
-        print(f'Failed to configure GPU: {e}')


### PR DESCRIPTION
## Summary
- Replace TensorFlow Decision Forests with scikit-learn RandomForest models and joblib serialization
- Drop TensorBoard integration and cleanup utilities
- Document tunable Random Forest parameters in README

## Testing
- `python -m py_compile train.py predict.py utils.py`
- `python train.py --csv-path ufc_fight_stats.csv --model-dir models_test --n-estimators 1 --max-depth 5 --random-state 0`
- `python predict.py --fighter1 "Alexa Grasso" --fighter2 "Valentina Shevchenko" --referee "Herb Dean" --model-dir models_test`


------
https://chatgpt.com/codex/tasks/task_e_689f5ab163948330b244802ef720c138