### PR TITLE
Add historical fighter statistics features

### DIFF
--- a/predict.py
+++ b/predict.py
@@ -3,8 +3,9 @@ import os
 
 import joblib
 import pandas as pd
+from scipy import sparse
 
-from utils import NUMERIC_COLS
+from utils import NUMERIC_COLS, load_data
 
 
 def load_models(model_dir: str = "models"):
@@ -20,11 +21,48 @@ def load_models(model_dir: str = "models"):
     return encoder, regressors, classifiers
 
 
-def predict(fighter1: str, fighter2: str, referee: str, encoder, regressors, classifiers):
-    X_new = pd.DataFrame(
-        {"fighter_1": [fighter1], "fighter_2": [fighter2], "referee": [referee]}
+def predict(
+    fighter1: str,
+    fighter2: str,
+    referee: str,
+    encoder,
+    regressors,
+    classifiers,
+    lookup,
+):
+    cat_features = ["fighter_1", "fighter_2", "referee"]
+    num_features = [
+        "fighter_1_winloss",
+        "fighter_1_avg_total_strikes",
+        "fighter_1_avg_control_time",
+        "fighter_1_avg_time",
+        "fighter_2_winloss",
+        "fighter_2_avg_total_strikes",
+        "fighter_2_avg_control_time",
+        "fighter_2_avg_time",
+    ]
+
+    f1_stats = lookup.get(fighter1, {})
+    f2_stats = lookup.get(fighter2, {})
+    row = {
+        "fighter_1": fighter1,
+        "fighter_2": fighter2,
+        "referee": referee,
+        "fighter_1_winloss": f1_stats.get("winloss", 0),
+        "fighter_1_avg_total_strikes": f1_stats.get("avg_total_strikes", 0),
+        "fighter_1_avg_control_time": f1_stats.get("avg_control_time", 0),
+        "fighter_1_avg_time": f1_stats.get("avg_time", 0),
+        "fighter_2_winloss": f2_stats.get("winloss", 0),
+        "fighter_2_avg_total_strikes": f2_stats.get("avg_total_strikes", 0),
+        "fighter_2_avg_control_time": f2_stats.get("avg_control_time", 0),
+        "fighter_2_avg_time": f2_stats.get("avg_time", 0),
+    }
+
+    X_new = pd.DataFrame([row])
+    X_cat = encoder.transform(X_new[cat_features])
+    X = sparse.hstack(
+        [X_cat, sparse.csr_matrix(X_new[num_features].values)], format="csr"
     )
-    X = encoder.transform(X_new)
     num_pred = {col: float(model.predict(X)[0]) for col, model in regressors.items()}
     cat_pred = {col: model.predict(X)[0] for col, model in classifiers.items()}
     result = dict(num_pred)
@@ -38,11 +76,60 @@ def main():
     parser.add_argument("--fighter2", required=True)
     parser.add_argument("--referee", required=True)
     parser.add_argument("--model-dir", default="models")
+    parser.add_argument("--csv-path", default="ufc_fight_stats.csv")
     args = parser.parse_args()
 
     encoder, regressors, classifiers = load_models(args.model_dir)
+    df = load_data(args.csv_path)
+    f1 = df[
+        [
+            "fighter_1",
+            "fighter_1_winloss",
+            "fighter_1_avg_total_strikes",
+            "fighter_1_avg_control_time",
+            "fighter_1_avg_time",
+        ]
+    ].rename(
+        columns={
+            "fighter_1": "fighter",
+            "fighter_1_winloss": "winloss",
+            "fighter_1_avg_total_strikes": "avg_total_strikes",
+            "fighter_1_avg_control_time": "avg_control_time",
+            "fighter_1_avg_time": "avg_time",
+        }
+    )
+    f2 = df[
+        [
+            "fighter_2",
+            "fighter_2_winloss",
+            "fighter_2_avg_total_strikes",
+            "fighter_2_avg_control_time",
+            "fighter_2_avg_time",
+        ]
+    ].rename(
+        columns={
+            "fighter_2": "fighter",
+            "fighter_2_winloss": "winloss",
+            "fighter_2_avg_total_strikes": "avg_total_strikes",
+            "fighter_2_avg_control_time": "avg_control_time",
+            "fighter_2_avg_time": "avg_time",
+        }
+    )
+    lookup_df = (
+        pd.concat([f1, f2], ignore_index=True)
+        .drop_duplicates(subset=["fighter"])
+        .set_index("fighter")
+    )
+    lookup = lookup_df.to_dict("index")
+
     prediction = predict(
-        args.fighter1, args.fighter2, args.referee, encoder, regressors, classifiers
+        args.fighter1,
+        args.fighter2,
+        args.referee,
+        encoder,
+        regressors,
+        classifiers,
+        lookup,
     )
     print(prediction)
 

--- a/predict.py
+++ b/predict.py
@@ -1,5 +1,6 @@
 import argparse
 import os
+import difflib
 
 import joblib
 import pandas as pd
@@ -21,66 +22,8 @@ def load_models(model_dir: str = "models"):
     return encoder, regressors, classifiers
 
 
-def predict(
-    fighter1: str,
-    fighter2: str,
-    referee: str,
-    encoder,
-    regressors,
-    classifiers,
-    lookup,
-):
-    cat_features = ["fighter_1", "fighter_2", "referee"]
-    num_features = [
-        "fighter_1_winloss",
-        "fighter_1_avg_total_strikes",
-        "fighter_1_avg_control_time",
-        "fighter_1_avg_time",
-        "fighter_2_winloss",
-        "fighter_2_avg_total_strikes",
-        "fighter_2_avg_control_time",
-        "fighter_2_avg_time",
-    ]
-
-    f1_stats = lookup.get(fighter1, {})
-    f2_stats = lookup.get(fighter2, {})
-    row = {
-        "fighter_1": fighter1,
-        "fighter_2": fighter2,
-        "referee": referee,
-        "fighter_1_winloss": f1_stats.get("winloss", 0),
-        "fighter_1_avg_total_strikes": f1_stats.get("avg_total_strikes", 0),
-        "fighter_1_avg_control_time": f1_stats.get("avg_control_time", 0),
-        "fighter_1_avg_time": f1_stats.get("avg_time", 0),
-        "fighter_2_winloss": f2_stats.get("winloss", 0),
-        "fighter_2_avg_total_strikes": f2_stats.get("avg_total_strikes", 0),
-        "fighter_2_avg_control_time": f2_stats.get("avg_control_time", 0),
-        "fighter_2_avg_time": f2_stats.get("avg_time", 0),
-    }
-
-    X_new = pd.DataFrame([row])
-    X_cat = encoder.transform(X_new[cat_features])
-    X = sparse.hstack(
-        [X_cat, sparse.csr_matrix(X_new[num_features].values)], format="csr"
-    )
-    num_pred = {col: float(model.predict(X)[0]) for col, model in regressors.items()}
-    cat_pred = {col: model.predict(X)[0] for col, model in classifiers.items()}
-    result = dict(num_pred)
-    result.update(cat_pred)
-    return result
-
-
-def main():
-    parser = argparse.ArgumentParser(description="Predict fight statistics and outcome")
-    parser.add_argument("--fighter1", required=True)
-    parser.add_argument("--fighter2", required=True)
-    parser.add_argument("--referee", required=True)
-    parser.add_argument("--model-dir", default="models")
-    parser.add_argument("--csv-path", default="ufc_fight_stats.csv")
-    args = parser.parse_args()
-
-    encoder, regressors, classifiers = load_models(args.model_dir)
-    df = load_data(args.csv_path)
+def build_lookup(df: pd.DataFrame) -> dict:
+    """Create a case-insensitive mapping of fighter names to stats."""
     f1 = df[
         [
             "fighter_1",
@@ -118,9 +61,86 @@ def main():
     lookup_df = (
         pd.concat([f1, f2], ignore_index=True)
         .drop_duplicates(subset=["fighter"])
-        .set_index("fighter")
+        .assign(key=lambda x: x["fighter"].str.lower())
+        .set_index("key")
     )
-    lookup = lookup_df.to_dict("index")
+    return lookup_df.to_dict("index")
+
+
+def get_fighter_stats(name: str, lookup: dict):
+    """Return canonical name and stats for a fighter using fuzzy matching."""
+    key = name.lower()
+    if key not in lookup:
+        matches = difflib.get_close_matches(key, lookup.keys(), n=1, cutoff=0.6)
+        if matches:
+            key = matches[0]
+        else:
+            return name, {}
+    data = lookup[key]
+    return data.get("fighter", name), data
+
+
+def predict(
+    fighter1: str,
+    fighter2: str,
+    referee: str,
+    encoder,
+    regressors,
+    classifiers,
+    lookup,
+):
+    cat_features = ["fighter_1", "fighter_2", "referee"]
+    num_features = [
+        "fighter_1_winloss",
+        "fighter_1_avg_total_strikes",
+        "fighter_1_avg_control_time",
+        "fighter_1_avg_time",
+        "fighter_2_winloss",
+        "fighter_2_avg_total_strikes",
+        "fighter_2_avg_control_time",
+        "fighter_2_avg_time",
+    ]
+
+    f1_name, f1_stats = get_fighter_stats(fighter1, lookup)
+    f2_name, f2_stats = get_fighter_stats(fighter2, lookup)
+    row = {
+        "fighter_1": f1_name,
+        "fighter_2": f2_name,
+        "referee": referee,
+        "fighter_1_winloss": f1_stats.get("winloss", 0),
+        "fighter_1_avg_total_strikes": f1_stats.get("avg_total_strikes", 0),
+        "fighter_1_avg_control_time": f1_stats.get("avg_control_time", 0),
+        "fighter_1_avg_time": f1_stats.get("avg_time", 0),
+        "fighter_2_winloss": f2_stats.get("winloss", 0),
+        "fighter_2_avg_total_strikes": f2_stats.get("avg_total_strikes", 0),
+        "fighter_2_avg_control_time": f2_stats.get("avg_control_time", 0),
+        "fighter_2_avg_time": f2_stats.get("avg_time", 0),
+    }
+
+    X_new = pd.DataFrame([row])
+    X_cat = encoder.transform(X_new[cat_features])
+    X = sparse.hstack(
+        [X_cat, sparse.csr_matrix(X_new[num_features].values)], format="csr"
+    )
+    num_pred = {col: float(model.predict(X)[0]) for col, model in regressors.items()}
+    cat_pred = {col: model.predict(X)[0] for col, model in classifiers.items()}
+    result = dict(num_pred)
+    result.update(cat_pred)
+    return result
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Predict fight statistics and outcome")
+    parser.add_argument("--fighter1", required=True)
+    parser.add_argument("--fighter2", required=True)
+    parser.add_argument("--referee", required=True)
+    parser.add_argument("--model-dir", default="models")
+    parser.add_argument("--csv-path", default="ufc_fight_stats.csv")
+    args = parser.parse_args()
+
+    encoder, regressors, classifiers = load_models(args.model_dir)
+    df = load_data(args.csv_path)
+    lookup = build_lookup(df)
 
     prediction = predict(
         args.fighter1,


### PR DESCRIPTION
## Summary
- calculate per-fighter win-loss record and average metrics from entire dataset
- add fighter-specific aggregates to preprocessing output
- include fighter historical aggregates as model features and use them during prediction

## Testing
- `pip install -r requirements.txt`
- `python train.py --n-estimators 10 --max-depth 5`
- `python predict.py --fighter1 "Alexa Grasso" --fighter2 "Valentina Shevchenko" --referee "Herb Dean"`


------
https://chatgpt.com/codex/tasks/task_e_68a17925ea8483308b2518e6936006b6