### PR TITLE
Use full fight history averages for model features

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 Using Tabular UFC fight data to predict winners from a given matchup
 
 ## Model Overview
-The training pipeline cleans raw fight statistics (for example converting "19 of 31" and "2:39" to numbers) and encodes fighter and referee names for use with [scikit-learn](https://scikit-learn.org/). Separate Random Forest models predict numeric fight statistics and categorical outcomes (result, method and round). Models and the feature encoder are saved with `joblib` for later prediction.
+The training pipeline cleans raw fight statistics (for example converting "19 of 31" and "2:39" to numbers) and encodes fighter and referee names for use with [scikit-learn](https://scikit-learn.org/). Separate Random Forest models predict numeric fight statistics and categorical outcomes (result, method and round). Models and the feature encoder are saved with `joblib` for later prediction. Fighter features now include historical averages for all tracked fight metrics, giving the models richer context for both training and prediction.
 
 ## Setup
 Install dependencies:

--- a/train.py
+++ b/train.py
@@ -8,7 +8,7 @@ from sklearn.metrics import mean_squared_error, accuracy_score
 from sklearn.preprocessing import OneHotEncoder
 from scipy import sparse
 
-from utils import NUMERIC_COLS, load_data
+from utils import NUMERIC_COLS, HISTORIC_STATS, load_data
 
 
 def train_models(
@@ -22,16 +22,11 @@ def train_models(
 
     df = load_data(csv_path)
     cat_features = ["fighter_1", "fighter_2", "referee"]
-    num_features = [
-        "fighter_1_winloss",
-        "fighter_1_avg_total_strikes",
-        "fighter_1_avg_control_time",
-        "fighter_1_avg_time",
-        "fighter_2_winloss",
-        "fighter_2_avg_total_strikes",
-        "fighter_2_avg_control_time",
-        "fighter_2_avg_time",
-    ]
+    num_features = ["fighter_1_winloss", "fighter_2_winloss"]
+    for stat in HISTORIC_STATS:
+        num_features.extend(
+            [f"fighter_1_avg_{stat}", f"fighter_2_avg_{stat}"]
+        )
     df_shuffled = df.sample(frac=1, random_state=random_state).reset_index(drop=True)
     split = int(len(df_shuffled) * 0.8)
     train_df = df_shuffled.iloc[:split]


### PR DESCRIPTION
## Summary
- compute per-fighter historical averages for all numeric fight stats
- train/predict using expanded fighter history features
- document richer historical features in README

## Testing
- `python train.py --csv-path ufc_fight_stats.csv --model-dir models_tmp --n-estimators 10 --max-depth 5`
- `python predict.py --fighter1 "Alexa Grasso" --fighter2 "Valentina Shevchenko" --referee "Herb Dean" --model-dir models_tmp --csv-path ufc_fight_stats.csv`


------
https://chatgpt.com/codex/tasks/task_e_68a26c3103e88330b91875fb9582b558