### PR TITLE
Cache fighter historical averages

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,10 +12,12 @@ pip install -r requirements.txt
 ```
 
 ## Training
-Train models and save them to the `models/` directory:
+Train models and save them to the `models/` directory. Historical per-fighter
+averages are cached to a separate CSV (`fighter_stats.csv` by default) and
+reused for both training and prediction:
 
 ```
-python train.py --csv-path ufc_fight_stats.csv --model-dir models
+python train.py --csv-path ufc_fight_stats.csv --model-dir models --fighter-stats-csv fighter_stats.csv
 ```
 
 ### Configurable Parameters
@@ -28,10 +30,11 @@ The training script exposes several arguments that can improve accuracy and prec
 Tune these parameters to balance bias and variance for your dataset.
 
 ## Prediction
-Load the saved models and generate predictions for a matchup:
+Load the saved models and generate predictions for a matchup (the same cached
+fighter statistics file is required):
 
 ```
-python predict.py --fighter1 "Alexa Grasso" --fighter2 "Valentina Shevchenko" --referee "Herb Dean"
+python predict.py --fighter1 "Alexa Grasso" --fighter2 "Valentina Shevchenko" --referee "Herb Dean" --fighter-stats-csv fighter_stats.csv
 ```
 
 The script prints predicted fight statistics along with the result, method and round.

--- a/predict.py
+++ b/predict.py
@@ -114,10 +114,15 @@ def main():
     parser.add_argument("--referee", required=True)
     parser.add_argument("--model-dir", default="models")
     parser.add_argument("--csv-path", default="ufc_fight_stats.csv")
+    parser.add_argument(
+        "--fighter-stats-csv",
+        default="fighter_stats.csv",
+        help="Path to cached fighter averages",
+    )
     args = parser.parse_args()
 
     encoder, regressors, classifiers = load_models(args.model_dir)
-    df = load_data(args.csv_path)
+    df = load_data(args.csv_path, args.fighter_stats_csv)
     lookup = build_lookup(df)
 
     prediction = predict(

--- a/train.py
+++ b/train.py
@@ -17,10 +17,11 @@ def train_models(
     n_estimators: int = 100,
     max_depth: Optional[int] = 10,
     random_state: int = 42,
+    fighter_stats_csv: str = "fighter_stats.csv",
 ) -> None:
     """Train scikit-learn Random Forest models for fight statistics and outcomes."""
 
-    df = load_data(csv_path)
+    df = load_data(csv_path, fighter_stats_csv)
     cat_features = ["fighter_1", "fighter_2", "referee"]
     num_features = ["fighter_1_winloss", "fighter_2_winloss"]
     for stat in HISTORIC_STATS:
@@ -104,6 +105,11 @@ if __name__ == "__main__":
     parser.add_argument("--csv-path", default="ufc_fight_stats.csv")
     parser.add_argument("--model-dir", default="models")
     parser.add_argument(
+        "--fighter-stats-csv",
+        default="fighter_stats.csv",
+        help="Path to cached fighter averages",
+    )
+    parser.add_argument(
         "--n-estimators", type=int, default=100, help="Number of trees in each forest"
     )
     parser.add_argument(
@@ -120,5 +126,6 @@ if __name__ == "__main__":
         n_estimators=args.n_estimators,
         max_depth=args.max_depth,
         random_state=args.random_state,
+        fighter_stats_csv=args.fighter_stats_csv,
     )
 


### PR DESCRIPTION
## Summary
- compute per-fighter historical averages once and cache to `fighter_stats.csv`
- allow training and prediction scripts to reuse cached fighter stats via `--fighter-stats-csv`
- document new workflow in README

## Testing
- `pip install numpy pandas scikit-learn tqdm joblib scipy`
- `python train.py --csv-path ufc_fight_stats.csv --model-dir models_test --fighter-stats-csv fighter_stats.csv --n-estimators 10 --max-depth 5 --random-state 0`
- `python predict.py --fighter1 "Conor McGregor" --fighter2 "Dustin Poirier" --referee "Herb Dean" --model-dir models_test --csv-path ufc_fight_stats.csv --fighter-stats-csv fighter_stats.csv`


------
https://chatgpt.com/codex/tasks/task_e_68a37995d0e883309694098e1ac29dd1