### PR TITLE
Add iterative prediction passes to random forest

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ The training script exposes several arguments that can improve accuracy and prec
 * `--n-estimators` – number of trees in each forest (default: 100)
 * `--max-depth` – maximum depth of each tree (default: unlimited)
 * `--random-state` – seed for reproducible splits and model initialization (default: 42)
+* `--num-passes` – number of iterative passes where model predictions are fed back as features (default: 1)
 
 Tune these parameters to balance bias and variance for your dataset.
 
@@ -37,4 +38,4 @@ fighter statistics file is required):
 python predict.py --fighter1 "Alexa Grasso" --fighter2 "Valentina Shevchenko" --referee "Herb Dean" --fighter-stats-csv fighter_stats.csv
 ```
 
-The script prints predicted fight statistics along with the result, method and round.
+The script prints predicted fight statistics along with the result, method and round. Use `--num-passes` with `predict.py` if the models were trained with more than one pass.


### PR DESCRIPTION
## Summary
- allow training Random Forest models over multiple passes, feeding previous predictions as features
- run prediction with the same iterative passes using per-pass models and label encoders
- document new `--num-passes` option in training and prediction scripts

## Testing
- `python -m py_compile train.py predict.py utils.py`
- `python train.py --csv-path ufc_fight_stats.csv --model-dir models --fighter-stats-csv fighter_stats.csv --n-estimators 5 --max-depth 5 --num-passes 2`
- `python predict.py --fighter1 "Alexa Grasso" --fighter2 "Valentina Shevchenko" --referee "Herb Dean" --fighter-stats-csv fighter_stats.csv --num-passes 2`


------
https://chatgpt.com/codex/tasks/task_e_68a386b55cc08330a4d184de2dbc86b9